### PR TITLE
Ignore sub-millisecond playhead movements

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -1006,7 +1006,8 @@ void TIME12AudioProcessor::processBlockByType (AudioBuffer<FloatType>& buffer, j
     }
 
     // keep beatPos in sync with playhead so plugin can be bypassed and return to its sync pos
-    if (playing) {
+    // some hosts (e.g. Ardour) quantize ppqPosition, so we ignore sub-millisecond adjustments
+    if (playing && std::abs(beatPos - ppqPosition) > 0.001) {
         beatPos = ppqPosition;
         ratePos = beatPos * secondsPerBeat * ratehz;
     }


### PR DESCRIPTION
For some hosts (e.g. Ardour), the ppqPosition reported is not sample-accurate; instead, it's quantized somehow to the internal clock. This leads to jitter in ppqPosition, which manifests itself as audible cracking (logs of small clicks). To avoid this, let's avoid syncing to the ppqPosition reported from host too eagerly, and just ignore the small adjustments.